### PR TITLE
Update project to use scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,19 @@ organization := "org.scalaj"
 
 version := "0.8"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")
 
-scalacOptions <++= scalaVersion map { (v: String) => 
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+
+scalacOptions ++= {
   Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-language:higherKinds")
+}
+
+scalacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 12)) => Seq()
+    case _ => Seq("-target:jvm-1.7")
+  }
 }
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/sbt
+++ b/sbt
@@ -1,19 +1,17 @@
 #!/bin/sh
 
-VERSION=0.13.6
-LATEST=http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${VERSION}/sbt-launch.jar
+VERSION=0.13.13
+LATEST=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${VERSION}/sbt-launch.jar
 JAR=.sbtlib/sbt-launch-${VERSION}.jar
 
 if [ ! -d .sbtlib ]; then
   mkdir .sbtlib
 fi
 
-
-
 if [ ! -f ${JAR} ]; then
   rm .sbtlib/*
   echo "Fetching sbt"
-  curl --progress-bar ${LATEST} > ${JAR}
+  curl -# -L "${LATEST}" -o "${JAR}"
 fi
 
 java \


### PR DESCRIPTION
Also this PR contains update for pgp plugin, because since sbt 0.13.5+ `addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")` should be used ([read more](http://www.scala-sbt.org/sbt-pgp/)).